### PR TITLE
Clear selection and focus after import

### DIFF
--- a/src/PolygonDraw/Map.tsx
+++ b/src/PolygonDraw/Map.tsx
@@ -199,7 +199,6 @@ export class BaseMap extends React.Component<Props, State> {
 
     handleImportPolygon = (coordinates: Coordinate[]) => {
         this.props.setPolygon(coordinates);
-        this.props.deselectAllPoints();
     };
 
     handleImportPolygonActionClicked = () => {

--- a/src/PolygonDraw/Map.tsx
+++ b/src/PolygonDraw/Map.tsx
@@ -199,6 +199,7 @@ export class BaseMap extends React.Component<Props, State> {
 
     handleImportPolygon = (coordinates: Coordinate[]) => {
         this.props.setPolygon(coordinates);
+        this.reframeOnPolygon(coordinates);
     };
 
     handleImportPolygonActionClicked = () => {

--- a/src/PolygonDraw/Map.tsx
+++ b/src/PolygonDraw/Map.tsx
@@ -199,6 +199,7 @@ export class BaseMap extends React.Component<Props, State> {
 
     handleImportPolygon = (coordinates: Coordinate[]) => {
         this.props.setPolygon(coordinates);
+        this.props.deselectAllPoints();
     };
 
     handleImportPolygonActionClicked = () => {

--- a/src/PolygonDraw/reducer.test.ts
+++ b/src/PolygonDraw/reducer.test.ts
@@ -38,6 +38,36 @@ describe('PolygonDraw reducer', () => {
         });
     });
 
+    describe('set polygon', () => {
+        it('should replace the active polygon', () => {
+            const state: PolygonEditState = {
+                activeIndex: 0,
+                polygons: [POLYGON_ONE],
+                selection: new Set()
+            };
+            const expectedState: PolygonEditState = {
+                activeIndex: 0,
+                polygons: [POLYGON_TWO],
+                selection: new Set()
+            };
+            expect(polygonEditReducer(state, actions.setPolygon(POLYGON_TWO))).toEqual(expectedState);
+        });
+
+        it('should remove any existing selection', () => {
+            const state: PolygonEditState = {
+                activeIndex: 0,
+                polygons: [POLYGON_ONE],
+                selection: new Set([0, 1, 2])
+            };
+            const expectedState: PolygonEditState = {
+                activeIndex: 0,
+                polygons: [POLYGON_TWO],
+                selection: new Set()
+            };
+            expect(polygonEditReducer(state, actions.setPolygon(POLYGON_TWO))).toEqual(expectedState);
+        });
+    });
+
     describe('Move points', () => {
         it('should move selected points', () => {
             const action = actions.moveSelectedPoints({ longitude: 0.1, latitude: 0.2 });

--- a/src/PolygonDraw/reducer.ts
+++ b/src/PolygonDraw/reducer.ts
@@ -38,7 +38,8 @@ export const polygonEditReducer = (state: PolygonEditState, action: Actions): Po
             newPolygons[state.activeIndex] = action.payload;
             return {
                 ...state,
-                polygons: newPolygons
+                polygons: newPolygons,
+                selection: new Set()
             };
         }
 

--- a/src/PolygonDraw/reducer.ts
+++ b/src/PolygonDraw/reducer.ts
@@ -34,11 +34,13 @@ export const polygonEditReducer = (state: PolygonEditState, action: Actions): Po
             };
         }
         case SET_POLYGON: {
-            const newPolygons = state.polygons.slice();
-            newPolygons[state.activeIndex] = action.payload;
             return {
                 ...state,
-                polygons: newPolygons,
+                polygons: [
+                    ...state.polygons.slice(0, state.activeIndex),
+                    action.payload,
+                    ...state.polygons.slice(state.activeIndex + 1)
+                ],
                 selection: new Set()
             };
         }


### PR DESCRIPTION
This PR clears the selection of the active polygon and reframes the imported polygon.