### PR TITLE
fix: prevent default for keyevents

### DIFF
--- a/src/PolygonDraw/Map.tsx
+++ b/src/PolygonDraw/Map.tsx
@@ -372,6 +372,7 @@ export class BaseMap extends React.Component<Props, State> {
     ///////////////////////////////////////////////////////////////////////////
 
     handleKeyDown = (e: KeyboardEvent) => {
+        e.preventDefault();
         switch (e.key) {
             case 'Escape':
                 this.props.deselectAllPoints();


### PR DESCRIPTION
In Firefox the backspace button triggers the "Go back" feature of the browser. This change prevents that.