### PR TITLE
Add undo and redo feature to PolygonDraw component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15022,6 +15022,11 @@
                 "symbol-observable": "^1.2.0"
             }
         },
+        "redux-undo": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/redux-undo/-/redux-undo-1.0.1.tgz",
+            "integrity": "sha512-0yFPT+FUgwxCEiS0Mg5T1S4tkgjR8h6sJRY9CW4EMsbJOf1SxO289TbJmlzhRouCHacdDF+powPjrjLHoJYxWQ=="
+        },
         "reflect.ownkeys": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
         "clipboard-polyfill": "^2.8.6",
         "leaflet-path-drag": "^1.1.0",
         "lodash.flatten": "^4.4.0",
-        "lodash.isequal": "^4.5.0"
+        "lodash.isequal": "^4.5.0",
+        "redux-undo": "^1.0.1"
     },
     "devDependencies": {
         "@babel/core": "^7.6.4",

--- a/src/PolygonDraw/Map.test.tsx
+++ b/src/PolygonDraw/Map.test.tsx
@@ -39,7 +39,9 @@ describe('Map component', () => {
             selectAllPoints: jest.fn(),
             moveSelectedPoints: jest.fn(),
             deletePolygonPoints: jest.fn(),
-            setPolygon: jest.fn()
+            setPolygon: jest.fn(),
+            onUndo: jest.fn(),
+            onRedo: jest.fn()
         };
     });
 

--- a/src/PolygonDraw/Map.tsx
+++ b/src/PolygonDraw/Map.tsx
@@ -59,6 +59,8 @@ export interface Props {
     deletePolygonPoints: () => void;
     selectAllPoints: () => void;
     setPolygon: (polygon: Coordinate[]) => void;
+    onUndo: () => void;
+    onRedo: () => void;
 }
 
 export interface State {
@@ -399,6 +401,13 @@ export class BaseMap extends React.Component<Props, State> {
                 break;
             case 'f':
                 this.reframe();
+                break;
+            case 'z':
+                if (e.metaKey && e.shiftKey) {
+                    this.props.onRedo();
+                } else if (e.metaKey) {
+                    this.props.onUndo();
+                }
                 break;
         }
     };

--- a/src/PolygonDraw/PolygonDraw.tsx
+++ b/src/PolygonDraw/PolygonDraw.tsx
@@ -47,7 +47,9 @@ export function PolygonDraw<T extends Coordinate[] | Coordinate[][]>({
         moveSelectedPoints,
         deletePolygonPoints,
         selectAllPoints,
-        isPolygonClosed
+        isPolygonClosed,
+        undo,
+        redo
     } = usePolygonEditor(onChange, polygon, activeIndex);
 
     return (
@@ -74,6 +76,8 @@ export function PolygonDraw<T extends Coordinate[] | Coordinate[][]>({
             onClick={onClick}
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
+            onUndo={undo}
+            onRedo={redo}
         />
     );
 }

--- a/src/PolygonDraw/reducer.ts
+++ b/src/PolygonDraw/reducer.ts
@@ -1,4 +1,4 @@
-import undoable, { groupByActionTypes, excludeAction } from 'redux-undo';
+import undoable, { excludeAction } from 'redux-undo';
 
 import {
     Actions,
@@ -150,7 +150,12 @@ export const polygonEditReducer = (state: PolygonEditState, action: Actions): Po
 export const EDIT_HISTORY_LIMIT = 20;
 
 export const undoablePolygonEditReducer = undoable(polygonEditReducer, {
-    groupBy: groupByActionTypes(MOVE_SELECTED_POINTS),
+    groupBy: (action, state, history) => {
+        if (action.type === MOVE_SELECTED_POINTS) {
+            return `${action.type}-${[...state.selection].sort().join('-')}`;
+        }
+        return null;
+    },
     filter: excludeAction([
         SELECT_POINTS,
         ADD_POINT_TO_SELECTION,
@@ -160,5 +165,7 @@ export const undoablePolygonEditReducer = undoable(polygonEditReducer, {
         CHANGE_POLYGON
     ]),
     // see https://github.com/omnidan/redux-undo/issues/6#issuecomment-142089793
-    limit: EDIT_HISTORY_LIMIT + 1
+    limit: EDIT_HISTORY_LIMIT + 1,
+    debug: false,
+    syncFilter: true
 });

--- a/src/PolygonDraw/reducer.ts
+++ b/src/PolygonDraw/reducer.ts
@@ -1,3 +1,5 @@
+import undoable, { groupByActionTypes, excludeAction } from 'redux-undo';
+
 import {
     Actions,
     SELECT_POINTS,
@@ -144,3 +146,19 @@ export const polygonEditReducer = (state: PolygonEditState, action: Actions): Po
         }
     }
 };
+
+export const EDIT_HISTORY_LIMIT = 20;
+
+export const undoablePolygonEditReducer = undoable(polygonEditReducer, {
+    groupBy: groupByActionTypes(MOVE_SELECTED_POINTS),
+    filter: excludeAction([
+        SELECT_POINTS,
+        ADD_POINT_TO_SELECTION,
+        REMOVE_POINT_FROM_SELECTION,
+        SELECT_ALL_POINTS,
+        DESELECT_ALL_POINTS,
+        CHANGE_POLYGON
+    ]),
+    // see https://github.com/omnidan/redux-undo/issues/6#issuecomment-142089793
+    limit: EDIT_HISTORY_LIMIT + 1
+});


### PR DESCRIPTION
Hi 👋 
in this PR we implemented "undo" (Cmd + z) and "redo" (Cmd + Shift + z) for the PolygonDraw component.