### PR TITLE
Fix: disable `automatic replace` story for chromatic

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -2,7 +2,7 @@ import { StorybookConfig } from '@storybook/react-webpack5';
 
 const config: StorybookConfig = {
     stories: ['../stories/**/*.(story|stories).@(tsx)'],
-    addons: ['@storybook/addon-essentials', '@storybook/addon-mdx-gfm'],
+    addons: ['@storybook/addon-essentials'],
     framework: {
         name: '@storybook/react-webpack5',
         options: {},

--- a/stories/PolygonDraw.stories.tsx
+++ b/stories/PolygonDraw.stories.tsx
@@ -88,6 +88,9 @@ export const AutomaticReplace = {
     },
 
     name: 'Automatic replace',
+    parameters: {
+        chromatic: { disableSnapshot: true },
+    },
 };
 
 export const New = () => (


### PR DESCRIPTION
This PR adds the `disableSnaptshot: true` option to the `Automatic replace` story as it caused the Chromatic builds to fail.