### PR TITLE
Refactor: remove lodash isEqual and flatten functions

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,8 +15,8 @@ module.exports = {
         '!**/*.d.ts'
     ],
     roots: ['<rootDir>/src'],
-    collectCoverageFrom: [
-        'src/modules/**/*.{ts,tsx}',
-        '!**/node_modules/**'
-    ],
+    // collectCoverageFrom: [
+    //     'src/modules/**/*.{ts,tsx}',
+    //     '!**/node_modules/**'
+    // ],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,8 +15,4 @@ module.exports = {
         '!**/*.d.ts'
     ],
     roots: ['<rootDir>/src'],
-    // collectCoverageFrom: [
-    //     'src/modules/**/*.{ts,tsx}',
-    //     '!**/node_modules/**'
-    // ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
                 "@mapbox/geojsonhint": "^3.1.0",
                 "leaflet-path-drag": "^1.8.0-beta.3",
                 "lodash.flatten": "^4.4.0",
-                "lodash.isequal": "^4.5.0",
                 "react-undo-redo": "^3.0.0"
             },
             "devDependencies": {
@@ -34,7 +33,6 @@
                 "@types/jest": "^29.4.0",
                 "@types/leaflet": "^1.9.1",
                 "@types/lodash.flatten": "^4.4.7",
-                "@types/lodash.isequal": "^4.5.6",
                 "@types/node": "^18.14.2",
                 "@types/react": "^18.0.28",
                 "@types/react-leaflet": "^3.0.0",
@@ -9252,15 +9250,6 @@
                 "@types/lodash": "*"
             }
         },
-        "node_modules/@types/lodash.isequal": {
-            "version": "4.5.6",
-            "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.6.tgz",
-            "integrity": "sha512-Ww4UGSe3DmtvLLJm2F16hDwEQSv7U0Rr8SujLUA2wHI2D2dm8kPu6Et+/y303LfjTIwSBKXB/YTUcAKpem/XEg==",
-            "dev": true,
-            "dependencies": {
-                "@types/lodash": "*"
-            }
-        },
         "node_modules/@types/mdast": {
             "version": "3.0.11",
             "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.11.tgz",
@@ -18132,11 +18121,6 @@
             "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
             "integrity": "sha512-ff3BX/tSioo+XojX4MOsOMhJw0nZoUEF011LX8g8d3gvjVbxd89cCio4BCXronjxcTUIJUoqKEUA+n4CqvvRPw==",
             "dev": true
-        },
-        "node_modules/lodash.isequal": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-            "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
         },
         "node_modules/lodash.memoize": {
             "version": "4.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
                 "@mapbox/geojson-rewind": "^0.5.2",
                 "@mapbox/geojsonhint": "^3.1.0",
                 "leaflet-path-drag": "^1.8.0-beta.3",
-                "lodash.flatten": "^4.4.0",
                 "react-undo-redo": "^3.0.0"
             },
             "devDependencies": {
@@ -32,7 +31,6 @@
                 "@testing-library/user-event": "^14.4.3",
                 "@types/jest": "^29.4.0",
                 "@types/leaflet": "^1.9.1",
-                "@types/lodash.flatten": "^4.4.7",
                 "@types/node": "^18.14.2",
                 "@types/react": "^18.0.28",
                 "@types/react-leaflet": "^3.0.0",
@@ -9241,15 +9239,6 @@
             "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
             "dev": true
         },
-        "node_modules/@types/lodash.flatten": {
-            "version": "4.4.7",
-            "resolved": "https://registry.npmjs.org/@types/lodash.flatten/-/lodash.flatten-4.4.7.tgz",
-            "integrity": "sha512-6yyP/mHEKL2sa86V61F7TnEcUKlLML9+aWI7TCKvnS4SFt7RD4zTVwkdDgluOJqxVkwZ/2z7HvtRs/7j/Uru7g==",
-            "dev": true,
-            "dependencies": {
-                "@types/lodash": "*"
-            }
-        },
         "node_modules/@types/mdast": {
             "version": "3.0.11",
             "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.11.tgz",
@@ -18110,11 +18099,6 @@
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
             "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
             "dev": true
-        },
-        "node_modules/lodash.flatten": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-            "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g=="
         },
         "node_modules/lodash.flow": {
             "version": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
         "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/geojsonhint": "^3.1.0",
         "leaflet-path-drag": "^1.8.0-beta.3",
-        "lodash.flatten": "^4.4.0",
         "react-undo-redo": "^3.0.0"
     },
     "devDependencies": {
@@ -66,7 +65,6 @@
         "@testing-library/user-event": "^14.4.3",
         "@types/jest": "^29.4.0",
         "@types/leaflet": "^1.9.1",
-        "@types/lodash.flatten": "^4.4.7",
         "@types/node": "^18.14.2",
         "@types/react": "^18.0.28",
         "@types/react-leaflet": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
         "@mapbox/geojsonhint": "^3.1.0",
         "leaflet-path-drag": "^1.8.0-beta.3",
         "lodash.flatten": "^4.4.0",
-        "lodash.isequal": "^4.5.0",
         "react-undo-redo": "^3.0.0"
     },
     "devDependencies": {
@@ -68,7 +67,6 @@
         "@types/jest": "^29.4.0",
         "@types/leaflet": "^1.9.1",
         "@types/lodash.flatten": "^4.4.7",
-        "@types/lodash.isequal": "^4.5.6",
         "@types/node": "^18.14.2",
         "@types/react": "^18.0.28",
         "@types/react-leaflet": "^3.0.0",

--- a/src/PolygonMap/PolygonMap.tsx
+++ b/src/PolygonMap/PolygonMap.tsx
@@ -1,24 +1,23 @@
-import { LatLngTuple } from 'leaflet';
-import flatten from 'lodash.flatten';
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { useMap } from 'react-leaflet';
+import { LatLngTuple } from 'leaflet'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useMap } from 'react-leaflet'
 
-import { ActionBar } from '../ActionBar/ActionBar';
-import { Modal } from '../common/components/Modal';
-import { MAP } from '../constants';
-import { ExportPolygonForm } from '../conversion/ExportPolygonForm';
-import { ImportPolygonForm } from '../conversion/ImportPolygonForm';
-import { createLeafletLatLngBoundsFromCoordinates } from '../helpers';
-import { Container, Map } from '../leaflet/Map';
-import { TileLayer } from '../leaflet/TileLayer';
-import { Coordinate, RectangleSelection } from '../types';
-import { BoundaryPolygon } from './components/BoundaryPolygon';
-import { ActivePolygon } from './components/ActivePolygon';
-import { InactivePolygon } from './components/InactivePolygon';
-import { PolygonPane } from './components/PolygonPane';
-import { Polyline } from './components/Polyline';
-import { SelectionRectangle } from './components/SelectionRectangle';
-import { MapInner } from './components/MapInner';
+import { ActionBar } from '../ActionBar/ActionBar'
+import { Modal } from '../common/components/Modal'
+import { MAP } from '../constants'
+import { ExportPolygonForm } from '../conversion/ExportPolygonForm'
+import { ImportPolygonForm } from '../conversion/ImportPolygonForm'
+import { createLeafletLatLngBoundsFromCoordinates } from '../helpers'
+import { Container, Map } from '../leaflet/Map'
+import { TileLayer } from '../leaflet/TileLayer'
+import { Coordinate, RectangleSelection } from '../types'
+import { ActivePolygon } from './components/ActivePolygon'
+import { BoundaryPolygon } from './components/BoundaryPolygon'
+import { InactivePolygon } from './components/InactivePolygon'
+import { MapInner } from './components/MapInner'
+import { PolygonPane } from './components/PolygonPane'
+import { Polyline } from './components/Polyline'
+import { SelectionRectangle } from './components/SelectionRectangle'
 
 export interface PolygonMapProps {
     activePolygon: Coordinate[];
@@ -103,7 +102,7 @@ export const PolygonMap = ({
 
     const reframeOnPolygon = (polygonCoordinates: Coordinate[] | Coordinate[][]) => {
         if (map.current && !!polygonCoordinates.length) {
-            const bounds = createLeafletLatLngBoundsFromCoordinates(flatten(polygonCoordinates));
+            const bounds = createLeafletLatLngBoundsFromCoordinates(polygonCoordinates.flat());
 
             map.current.fitBounds(bounds);
         }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,5 +1,4 @@
 import { LatLng, LatLngBounds, LatLngTuple } from 'leaflet';
-import isEqual from 'lodash.isequal';
 
 import { Coordinate } from './types';
 
@@ -30,7 +29,7 @@ export const subtractCoordinates = (coordA: Coordinate, coordB: Coordinate): Coo
 });
 
 export const isPolygonClosed = (coordinates: Coordinate[]): boolean =>
-    coordinates && coordinates.length > 2 && isEqual(coordinates[0], coordinates[coordinates.length - 1]);
+    coordinates && coordinates.length > 2 && isSameCoordinate(coordinates[0], coordinates[coordinates.length - 1]);
 
 export const isClosingPointsSelected = (coordinates: Coordinate[], selection: Set<number>): boolean =>
     isPolygonClosed(coordinates) && (selection.has(coordinates.length - 1) || selection.has(0));
@@ -74,14 +73,18 @@ export const movePolygonCoordinates = (
     });
 };
 
+const isSameCoordinate = (firstCoordinate: Coordinate, secondCoordinate: Coordinate) =>
+    firstCoordinate.latitude === secondCoordinate.latitude &&
+    firstCoordinate.longitude === secondCoordinate.longitude;
+
 export const removeSelectedPoints = (polygonCoordinates: Coordinate[], selectedPoints: Set<number>) => {
     const newPolygonCoordinates = polygonCoordinates.filter((polygonCoordinate, index) => !selectedPoints.has(index));
     const isOldPathClosed =
         polygonCoordinates.length > 1 &&
-        isEqual(polygonCoordinates[0], polygonCoordinates[polygonCoordinates.length - 1]);
+        isSameCoordinate(polygonCoordinates[0], polygonCoordinates[polygonCoordinates.length - 1]);
     const isNewPathClosed =
         newPolygonCoordinates.length > 1 &&
-        isEqual(newPolygonCoordinates[0], newPolygonCoordinates[newPolygonCoordinates.length - 1]);
+        isSameCoordinate(newPolygonCoordinates[0], newPolygonCoordinates[newPolygonCoordinates.length - 1]);
 
     // Open closed path if it has 3 points or less
     if (newPolygonCoordinates.length < 4 && isNewPathClosed) {
@@ -114,7 +117,7 @@ export const getCenterCoordinate = (coordA: Coordinate, coordB: Coordinate): Coo
 // Returns the center coordinates of the polygon edges
 export const getPolygonEdges = (polygon: Coordinate[]) =>
     polygon.reduce<Coordinate[]>((edges, coordinate, index) => {
-        if (index === 0 || isEqual(polygon[index], polygon[index - 1])) {
+        if (index === 0 || isSameCoordinate(polygon[index], polygon[index - 1])) {
             return edges;
         }
         edges.push(getCenterCoordinate(polygon[index], polygon[index - 1]));


### PR DESCRIPTION
Since we are aiming to reduce the bundle size, I've taken a look at the lodash methods and even though `flatten` only takes about `1kb`, the `isEqual` was taking about `10kb` of the bundle. Since both methods were being used in a simple way, I was able to substitute them:
- `lodash.flatten` was substituted by simply using `Array.prototype.flat()`
- `lodash.isEqual` was substituted for the custom helper function `isSameCoordinate` that given two Coordinates, it will check if their latitude and longitude are the same.